### PR TITLE
Revamped Makefile, added more comments to example code, fixed segfault issue on shader creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 CXXFLAGS = -std=c++17
 
+SHADERS = $(wildcard example/*.cl)
+SPVS = $(patsubst example/%.cl,build/%.spv,$(SHADERS))
+CINITS = $(patsubst example/%.cl,build/%.cinit,$(SHADERS))
+
+.PHONY: all clean easyvk example
+
 all: build easyvk
 
 build:
@@ -7,6 +13,16 @@ build:
 
 easyvk: build src/easyvk.cpp src/easyvk.h
 	$(CXX) $(CXXFLAGS) -Isrc -c src/easyvk.cpp -o build/easyvk.o
+
+example: build easyvk $(SPVS) $(CINITS)
+	$(CXX) $(CXXFLAGS) -Isrc -Ibuild -c example/vect-add.cpp -o build/vect-add.o
+	$(CXX) $(CXXFLAGS) build/easyvk.o build/vect-add.o -lvulkan -o build/vect-add
+
+build/%.spv: example/%.cl
+	clspv -cl-std=CL2.0 -inline-entry-points $< -o $@
+
+build/%.cinit: example/%.cl
+	clspv -cl-std=CL2.0 -inline-entry-points -output-format=c $< -o $@
 	
 clean:
-	rm -r build
+	rm -rf build

--- a/example/vect-add.cpp
+++ b/example/vect-add.cpp
@@ -7,33 +7,49 @@
 const int size = 4;
 
 int main(int argc, char* argv[]) {
+	// Initialize 
 	auto instance = easyvk::Instance(true);
 	auto device = instance.devices().at(0);
-	// std::cout << "Using device: " << device.properties().deviceName << "\n";
+	std::cout << "Using device: " << device.properties.deviceName << "\n";
 
+	// Create GPU buffers.
 	auto a = easyvk::Buffer(device, size);
 	auto b = easyvk::Buffer(device, size);
 	auto c = easyvk::Buffer(device, size);
 
+	// Write initial values to the buffers.
 	for (int i = 0; i < size; i++) {
 		a.store(i, i);
 		b.store(i, i + 1);
 		c.store(i, 0);
 	}
 	std::vector<easyvk::Buffer> bufs = {a, b, c};
+
+	// Kernel source code can be loaded in two ways: 
+	// 1. .spv binary read from file at runtime.
 	const char* testFile = "build/vect-add.spv";
+	// 2. .spv binary loaded into the executable at compile time.
 	std::vector<uint32_t> spvCode =
-    #include "vect-add.cinit"
-    ;	
+	#include "vect-add.cinit"
+	;	
 	auto program = easyvk::Program(device, spvCode, bufs);
+	// auto program = easyvk::Program(device, testFile, bufs);
+
+	// Dispatch 4 work groups of size 1 to carry out the work.
 	program.setWorkgroups(size);
 	program.setWorkgroupSize(1);
+
+	// Run the kernel.
 	program.prepare();
 	program.run();
+
+	// Print and check the output.
 	for (int i = 0; i < size; i++) {
 		std::cout << "c[" << i << "]: " << c.load(i) << "\n";
 		assert(c.load(i) == a.load(i) + b.load(i));
 	}
+
+	// Cleanup.
 	program.teardown();
 	a.teardown();
 	b.teardown();

--- a/example/vect-add.cpp
+++ b/example/vect-add.cpp
@@ -1,13 +1,15 @@
 #include <vector>
 #include <iostream>
 #include <easyvk.h>
+#include <cassert>
+#include <vector>
 
 const int size = 4;
 
 int main(int argc, char* argv[]) {
 	auto instance = easyvk::Instance(true);
 	auto device = instance.devices().at(0);
-	std::cout << "Using device: " << device.properties().deviceName << "\n";
+	// std::cout << "Using device: " << device.properties().deviceName << "\n";
 
 	auto a = easyvk::Buffer(device, size);
 	auto b = easyvk::Buffer(device, size);
@@ -19,9 +21,11 @@ int main(int argc, char* argv[]) {
 		c.store(i, 0);
 	}
 	std::vector<easyvk::Buffer> bufs = {a, b, c};
-	const char* testFile = "vect-add.spv";
-
-	auto program = easyvk::Program(device, testFile, bufs);
+	const char* testFile = "build/vect-add.spv";
+	std::vector<uint32_t> spvCode =
+    #include "vect-add.cinit"
+    ;	
+	auto program = easyvk::Program(device, spvCode, bufs);
 	program.setWorkgroups(size);
 	program.setWorkgroupSize(1);
 	program.prepare();

--- a/src/easyvk.cpp
+++ b/src/easyvk.cpp
@@ -416,6 +416,7 @@ namespace easyvk {
 			spvCode.size() * sizeof(uint32_t),
 			spvCode.data()
 		}, nullptr, &shaderModule));
+
 		return shaderModule;
 	}
 	VkShaderModule initShaderModule(easyvk::Device& device, const char* filepath) {
@@ -494,8 +495,10 @@ namespace easyvk {
 			VkPipelineShaderStageCreateFlags {},
 			VK_SHADER_STAGE_COMPUTE_BIT,
 			shaderModule,
-			"lock_test",
+			"litmus_test", // TODO: Set entyr-point name in a way which isn't just hard-coded.
 			&specInfo};
+
+
 		// Define compute pipeline create info
 		VkComputePipelineCreateInfo pipelineCI{
 			VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
@@ -505,8 +508,10 @@ namespace easyvk {
 			pipelineLayout
 		};
 
+
 		// Create compute pipelines
 		vkCheck(vkCreateComputePipelines(device.device, {}, 1, &pipelineCI, nullptr,  &pipeline));
+		std::printf("Created compute pipeline!\n");
 
 		// Start recording command buffer
 		vkCheck(vkBeginCommandBuffer(device.computeCommandBuffer, new VkCommandBufferBeginInfo {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}));


### PR DESCRIPTION
It seems like before you were hardcoding the kernel entry point which was causing segfault. We could just leave this as is or I could write a simple function like `setEntryPoint` in the Program class to just make it explicit. 

There may also be ways to automatically get the entry point name from the .spv code (see https://github.com/KhronosGroup/SPIRV-Reflect/blob/b68b5a8a5d8ab5fce79e6596f3a731291046393a/spirv_reflect.h#L1692).