### PR TITLE
Adds statistics on an executable (i.e. compiled shader)

### DIFF
--- a/src/easyvk.cpp
+++ b/src/easyvk.cpp
@@ -724,16 +724,17 @@ namespace easyvk
         stats.push_back(ShaderStatistics{ stat.name, stat.description, 0, stat.value.b32 });
         break;
       case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_INT64_KHR:
-        stats.push_back(ShaderStatistics{ stat.name, stat.description, 1, stat.value.i64 });
+        stats.push_back(ShaderStatistics{ stat.name, stat.description, 1, (uint64_t) stat.value.i64 });
         break;
       case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_UINT64_KHR:
         stats.push_back(ShaderStatistics{ stat.name, stat.description, 2, stat.value.u64 });
         break;
       case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_FLOAT64_KHR:
-        stats.push_back(ShaderStatistics{ stat.name, stat.description, 3, stat.value.f64 });
+        stats.push_back(ShaderStatistics{ stat.name, stat.description, 3, (uint64_t) stat.value.f64 });
         break;
       }
     }
+    return stats;
   }
 
   void Program::run()

--- a/src/easyvk.cpp
+++ b/src/easyvk.cpp
@@ -308,6 +308,14 @@ namespace easyvk
         1,
         &priority};
 
+    uint32_t pPropertyCount;
+    vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &pPropertyCount, nullptr);
+    std::vector<VkExtensionProperties> extensions(pPropertyCount);
+    vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &pPropertyCount, extensions.data()); 
+    for (const auto& extension : extensions) {
+      evk_log("Extension: %s\n", extension.extensionName);
+    }
+
     // enable pipeline executable properties reporting
     VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR pipelineProperties = {};
     pipelineProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR;

--- a/src/easyvk.cpp
+++ b/src/easyvk.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "easyvk.h"
+#include <string.h>
 
 // TODO: extend this to include ios logging lib
 void evk_log(const char *fmt, ...)

--- a/src/easyvk.h
+++ b/src/easyvk.h
@@ -58,6 +58,8 @@ namespace easyvk
     uint32_t computeFamilyId = uint32_t(-1);
     uint32_t subgroupSize();
     VkQueue computeQueue;
+    // AMD shader info extension gives more register info than the portable stats extension
+    bool supportsAMDShaderStats;
     void teardown();
 
   private:

--- a/src/easyvk.h
+++ b/src/easyvk.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <fstream>
 #include <set>
+#include <string>
 #include <stdarg.h>
 #include <vector>
 #include <map>
@@ -162,6 +163,13 @@ namespace easyvk
     void *data;
   };
 
+  typedef struct ShaderStatistics {
+    std::string name;
+    std::string description;
+    size_t format; // 0 -> bool, 1 -> int64, 2 -> uint64, 3 -> float64
+    uint64_t value; // may need to cast this to get the right value based on the format
+  } ShaderStatistics;
+
   /**
    * A program consists of shader code and the buffers/inputs to the shader
    * Buffers should be passed in according to their argument order in the shader.
@@ -174,7 +182,7 @@ namespace easyvk
     Program(Device &_device, std::vector<uint32_t> spvCode, std::vector<easyvk::Buffer> &buffers);
     void initialize(const char *entry_point);
     void run();
-    void getShaderStats();
+    std::vector<ShaderStatistics> getShaderStats();
     float runWithDispatchTiming();
     void setWorkgroups(uint32_t _numWorkgroups);
     void setWorkgroupSize(uint32_t _workgroupSize);

--- a/src/easyvk.h
+++ b/src/easyvk.h
@@ -172,6 +172,7 @@ namespace easyvk
     Program(Device &_device, std::vector<uint32_t> spvCode, std::vector<easyvk::Buffer> &buffers);
     void initialize(const char *entry_point);
     void run();
+    void getShaderStats();
     float runWithDispatchTiming();
     void setWorkgroups(uint32_t _numWorkgroups);
     void setWorkgroupSize(uint32_t _workgroupSize);

--- a/src/easyvk.h
+++ b/src/easyvk.h
@@ -181,8 +181,8 @@ namespace easyvk
     Program(Device &_device, const char *filepath, std::vector<easyvk::Buffer> &buffers);
     Program(Device &_device, std::vector<uint32_t> spvCode, std::vector<easyvk::Buffer> &buffers);
     void initialize(const char *entry_point);
-    void run();
     std::vector<ShaderStatistics> getShaderStats();
+    void run();
     float runWithDispatchTiming();
     void setWorkgroups(uint32_t _numWorkgroups);
     void setWorkgroupSize(uint32_t _workgroupSize);


### PR DESCRIPTION
The pipeline executable extension returns statistics about a compiled shader from a pipeline, particularly things like register pressure, which is useful/interesting for our work. Also, AMD supports its own statistics extension, which I enable here if the device supports it.

Adds a method to the `Program` class that returns these statistics in a vector, as long as the pipeline has been initialized.