### PR TITLE
Adding clear and fill command to buffers

### DIFF
--- a/src/easyvk.h
+++ b/src/easyvk.h
@@ -97,7 +97,9 @@ namespace easyvk
     void teardown();
     void copy(Buffer dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);  
     void store(void* src, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);
-    void load(void* dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0); 
+    void load(void* dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);
+		void clear();
+		void fill(uint32_t word, size_t offset = 0); 
     void _copy(VkBuffer src, VkBuffer dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);
 
     easyvk::Device &device;

--- a/src/easyvk.h
+++ b/src/easyvk.h
@@ -98,8 +98,8 @@ namespace easyvk
     void copy(Buffer dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);  
     void store(void* src, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);
     void load(void* dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);
-		void clear();
-		void fill(uint32_t word, size_t offset = 0); 
+    void clear();
+    void fill(uint32_t word, size_t offset = 0); 
     void _copy(VkBuffer src, VkBuffer dst, size_t len, size_t srcOffset = 0, size_t dstOffset = 0);
 
     easyvk::Device &device;


### PR DESCRIPTION
Update to the interface merged in #16, adding a `Buffer::clear()` and `Buffer::fill()` command (the former relying on the latter) that uses vkCmdFillBuffer, because we use clear() in some sync benchmark stuff and it seems useful.